### PR TITLE
Refactor scripts

### DIFF
--- a/utils/scripts/setup-lf.bash
+++ b/utils/scripts/setup-lf.bash
@@ -1,46 +1,86 @@
 #!/bin/bash
 # This script sets up LF runtime.
-set -ux
+set -u
+
+# https://stackoverflow.com/a/7662661
+is_valid_sha1() {
+    case $1 in
+    *[!0-9A-Fa-f]* | "") return 1 ;;
+    *)
+        case ${#1} in
+        40) return 0 ;;
+        *) return 2 ;;
+        esac
+        ;;
+    esac
+}
 
 RELEASE_BUILD="nightly"
-EXAMPLE=0
+CHECK_INSANE_NAMES=true
+REF=""
+REPO_URL="https://github.com/lf-lang/lingua-franca.git"
 
 for arg in "$@"; do
     shift
     case "$arg" in
-        'dev') RELEASE_BUILD="dev";;
-        'stable') RELEASE_BUILD="stable";;
-        '--example') EXAMPLE=1;;
+    dev) RELEASE_BUILD="dev" ;;
+    stable) RELEASE_BUILD="stable" ;;
+    --skip-check-insane-names) CHECK_INSANE_NAMES=false ;;
+    --debug) set -x ;;
+    --ref=*) REF=${arg#--ref=} ;;
+    --custom-repo-url=*) REPO_URL=${arg#--custom-repo-url=} ;;
+
     esac
 done
 
-
 # Use case here for maximum flexibility if we were to change later
-if [ ! -d "lingua-franca" ]; then
-    case "$RELEASE_BUILD" in
-        'dev') 
-            git clone https://github.com/lf-lang/lingua-franca.git --branch master --depth 1
-            cd lingua-franca
-            git submodule update --init --recursive
-            ./gradlew buildAll
-            cd .. 
-        ;;
-        *) 
-            echo "::step:: Getting lf executable......"
-            python3 "$(dirname $0)/get-lf-executable" $RELEASE_BUILD
-            mkdir lingua-franca
-            # While what we have here is tar.gz, lf release bot appear to have a bug and did not gunzip it.
-            # Therefore `tar -xzf` will fail but `tar -xf` will work.
-            # Here, we ignore the actual build name (the original name of the file and the original first directory). 
-            tar -xf lf.tar.gz -C lingua-franca --strip-components 1
-            rm lf.tar.gz
-        ;;
-    esac
-else
-    echo "::step:: Directory lingua-franca already exist. Ignoring fetch."
+if [ -d "lingua-franca" ]; then
+    echo "Directory lingua-franca already exists. Removing it......"
+    rm -rf lingua-franca
 fi
 
-if [ $EXAMPLE -eq 1 ] && [ ! -d "examples" ] ; then
-    echo "::step:: Cloning examples......"
-    git clone https://github.com/lf-lang/examples-lingua-franca.git examples --branch main
-fi
+case "$RELEASE_BUILD" in
+'dev')
+    BRANCH_TO_FETCH="master"
+    SHA=""
+    if [ -n "${REF}" ]; then
+        is_valid_sha1 "${REF}"
+        result=$?
+        case $result in
+        0) SHA=${REF} ;;
+        1)
+            BRANCH_TO_FETCH="${REF}"
+            ;;
+        2)
+            if [ $CHECK_INSANE_NAMES = true ]; then
+                echo "It appears that you passed in a prefix of SHA-1 as ref."
+                echo "Unfortunately, git only allows fetching full 40 character remote SHA-1."
+                echo "If you want to fetch a branch with SHA-1-esque name, pass in --skip-check-insane-names as argument."
+                echo "I will fetch branch master for you instead."
+            else
+                BRANCH_TO_FETCH="${REF}"
+            fi
+            ;;
+        esac
+    fi
+    git clone --branch ${BRANCH_TO_FETCH} --depth 1 "${REPO_URL}" lingua-franca
+    pushd lingua-franca || exit 1
+    if [ -n "${SHA}" ]; then
+        git fetch --depth=1 origin "${SHA}"
+        git switch --detach "${SHA}"
+    fi
+    git submodule update --init --recursive
+    ./gradlew assemble
+    popd || exit 1
+    ;;
+*)
+    echo "::step:: Getting lf executable......"
+    python3 "$(dirname "$0")/get-lf-executable" $RELEASE_BUILD
+    mkdir lingua-franca
+    # While what we have here is tar.gz, lf release bot appear to have a bug and did not gunzip it.
+    # Therefore `tar -xzf` will fail but `tar -xf` will work.
+    # Here, we ignore the actual build name (the original name of the file and the original first directory).
+    tar -xf lf.tar.gz -C lingua-franca --strip-components 1
+    rm lf.tar.gz
+    ;;
+esac

--- a/utils/scripts/setup-lf.bash
+++ b/utils/scripts/setup-lf.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script sets up LF runtime.
-set -euxo pipefail
+set -ux
 
 RELEASE_BUILD="nightly"
 EXAMPLE=0

--- a/utils/scripts/setup-user-env.bash
+++ b/utils/scripts/setup-user-env.bash
@@ -1,7 +1,7 @@
 #!/bin/bash -i
 # This script specifically detects and set up nvm and SDKMAN in bash environment, and install
 # needed components for LF
-set -euxo pipefail
+set -ux
 
 # Check if SDK is installed like what SDKMAN installer does
 install_sdk(){


### PR DESCRIPTION
This PR:
Updates `setup-lf.bash` and `setup-user-env.bash` to remove `set -e`. While it is a good practice to fail the script if anything goes wrong, in this repo it will crash the whole devcontainer installation which is not good. The root cause is that they are run in nondeterministic environments and will explode for some reason. Since they are run after the container is created, failure to execute shouldn't be a big deal, as users can run them again easily.
This, of course, is like cutting one's head off to cure headache - it solves errors by not emitting errors. But on the other hand, a correctly built container could contain more debugging info.

This also allows passing a `--ref=` argument into `setup-lf.bash` which could potentially be useful. Also removed example cloning and purge lf dir functionality.