### PR TITLE
Bump vscode extension version to pre-release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
       },
       "vscode": {
         "extensions": [
-          "lf-lang.vscode-lingua-franca",
+          "lf-lang.vscode-lingua-franca@prerelease",
           "kieler.klighd-vscode"
         ]
       }

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -32,5 +32,5 @@ tasks:
 
 vscode: 
   extensions:
-    - lf-lang.vscode-lingua-franca
+    - lf-lang.vscode-lingua-franca@prerelease
     - kieler.klighd-vscode


### PR DESCRIPTION
While the current stable extension is too outdated, this let's Codespaces/GitPod users load the pre-release version of the VS Code extension by default.