### PR TITLE
Fix #68 remaining problems

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
     "remoteEnv": {
         // Unsure if this is a good idea, as other people might fork this and change name
         "LF_PATH": "${containerWorkspaceFolder}/lingua-franca",
-        "PATH": "${containerEnv:PATH}:${containerWorkspaceFolder}/lingua-franca/bin"
+        // We must include SDKMAN here, because otherwise node which VSCode uses will disregard new java installed by SDKMAN, LF extension will get confused and use the old version.
+        "PATH": "${containerWorkspaceFolder}/lingua-franca/bin:/home/vscode/.sdkman/candidates/java/current/bin:${containerEnv:PATH}"
     },
     "customizations": {
       "codespaces": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         // Unsure if this is a good idea, as other people might fork this and change name
         "LF_PATH": "${containerWorkspaceFolder}/lingua-franca",
         // We must include SDKMAN here, because otherwise node which VSCode uses will disregard new java installed by SDKMAN, LF extension will get confused and use the old version.
-        "PATH": "${containerWorkspaceFolder}/lingua-franca/bin:/home/vscode/.sdkman/candidates/java/current/bin:${containerEnv:PATH}"
+        "PATH": "${containerWorkspaceFolder}/lingua-franca/bin:$SDKMAN_DIR/candidates/java/current/bin:${containerEnv:PATH}"
     },
     "customizations": {
       "codespaces": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
         // Unsure if this is a good idea, as other people might fork this and change name
         "LF_PATH": "${containerWorkspaceFolder}/lingua-franca",
         // We must include SDKMAN here, because otherwise node which VSCode uses will disregard new java installed by SDKMAN, LF extension will get confused and use the old version.
-        "PATH": "${containerWorkspaceFolder}/lingua-franca/bin:$SDKMAN_DIR/candidates/java/current/bin:${containerEnv:PATH}"
+        // Not portable. But what can you do?
+        "PATH": "${containerWorkspaceFolder}/lingua-franca/bin:/home/vscode/.sdkman/candidates/java/current/bin:${containerEnv:PATH}"
     },
     "customizations": {
       "codespaces": {

--- a/utils/scripts/setup-user-env.bash
+++ b/utils/scripts/setup-user-env.bash
@@ -1,6 +1,8 @@
 #!/bin/bash -i
-# This script specifically detects and set up nvm and SDKMAN in bash environment, and install
-# needed components for LF
+# This script specifically detects and set up nvm and SDKMAN in bash environment, and install needed components for LF.
+# The sad fact is that while this script should not at all be an interactive shell, both NVM and SDK puts, by default, their settings in .bashrc, which is inappropriate, and we need some parts of it to check if the installation is complete.
+# There are many side effects of a login shell, logging history is just one - but at least we need to turn it off!
+unset HISTFILE
 set -ux
 
 # Check if SDK is installed like what SDKMAN installer does


### PR DESCRIPTION
1. setup-user-env uses interactive shell but shouldn't log to bash history
2. in codespaces the extension cannot read PATH updated in `postStartCommand`
Context:
> For bash history garbage, the background is bash will run .bashrc only if it is an interactive shell. Because both nvm and sdkman will only write their config to .bashrc, we have to use interactive shell, and it by default write to history.
> 
> For LF extension, it is because, for some reason, PATH is set AFTER node which vscode depends on start up. Our extension uses promisify("java --version") which will use PATH when it starts up, and that causes problems. This doesn't make sense as the same thing happens on gitpod, but this is the only way which I could convince me.
> 
> I had a temporary fix that is very non-portable (add the path to SDKMAN to container settings), but I think a better solution is to spawn a new shell or something, because the current implementation is basically that all the environment variables which it uses (which is quite common) will depend on whichever was there when node started up, and cannot be changed

## Please squash