### PR TITLE
[CI] Don't run build-devcontainer when nothing related was changed

### DIFF
--- a/.github/workflows/check-devcontainer.yml
+++ b/.github/workflows/check-devcontainer.yml
@@ -27,7 +27,7 @@ jobs:
 
   build-devcontainer:
     needs: check-devcontainer-changed
-    if: ${{ needs.changes.outputs.devcontainer == 'true' }} || ${{ needs.changes.outputs.docker == 'true' }} || ${{ needs.changes.outputs.scripts == 'true' }}
+    if: ${{ needs.changes.outputs.devcontainer == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.scripts == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (GitHub)


### PR DESCRIPTION
This was how I structured the code; yet I recently discovered that step runs regardless and the issue seems to be purely syntactical. 

Proof that it works: this PR shouldn't trigger build-devcontainer