### PR TITLE
Fix CI randomly failing Use chmod instead of chown

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     // Uncomment this line if GitHub displays no enough space
     "waitFor": "postCreateCommand",
     "updateContentCommand": "",
-    "onCreateCommand": "sudo mkdir -p /workspaces/.codespaces/.persistedshare/logs && sudo chown -R vscode /workspaces/.codespaces/.persistedshare/logs",
+    "onCreateCommand": "sudo mkdir -p /workspaces/.codespaces/.persistedshare/logs && sudo chown -R `whoami` /workspaces/.codespaces/.persistedshare/logs",
     "postStartCommand": {
       "setup-user-env": ["/bin/bash", "-c", "(bash -i ./utils/scripts/setup-user-env.bash >> /workspaces/.codespaces/.persistedshare/logs/stdout-env.log 2>> /workspaces/.codespaces/.persistedshare/logs/stderr-env.log) || (echo setup-user-env exited with nonzero code)"],
       "setup-lf": ["/bin/bash", "-c", "(bash ./utils/scripts/setup-lf.bash nightly >> /workspaces/.codespaces/.persistedshare/logs/stdout-lf.log 2>> /workspaces/.codespaces/.persistedshare/logs/stderr-lf.log) || (echo setup-lf exited with nonzero code)"],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     // Uncomment this line if GitHub displays no enough space
     "waitFor": "postCreateCommand",
     "updateContentCommand": "",
-    "onCreateCommand": "sudo mkdir -p /workspaces/.codespaces/.persistedshare/logs && sudo chown -R `whoami` /workspaces/.codespaces/.persistedshare/logs",
+    "onCreateCommand": "sudo mkdir -p /workspaces/.codespaces/.persistedshare/logs && sudo chmod -R 777 /workspaces/.codespaces/.persistedshare/logs",
     "postStartCommand": {
       "setup-user-env": ["/bin/bash", "-c", "(bash -i ./utils/scripts/setup-user-env.bash >> /workspaces/.codespaces/.persistedshare/logs/stdout-env.log 2>> /workspaces/.codespaces/.persistedshare/logs/stderr-env.log) || (echo setup-user-env exited with nonzero code)"],
       "setup-lf": ["/bin/bash", "-c", "(bash ./utils/scripts/setup-lf.bash nightly >> /workspaces/.codespaces/.persistedshare/logs/stdout-lf.log 2>> /workspaces/.codespaces/.persistedshare/logs/stderr-lf.log) || (echo setup-lf exited with nonzero code)"],


### PR DESCRIPTION
Our previous setting should be working perfectly, but `devcontainers/ci@v0.3` seems to have many problems that we might need to address. In short, it might run these command while user `vscode` was not yet created.


This is the only cause I could think of that causes the command to fail, but I don't know why it fails. Dealing with such an under-development and poorly designed product outside of our control where no debugging information is emitted with nondeterministic result (see https://github.com/axmmisaka/examples-lingua-franca/actions/runs/5695452106; changing examples shouldn't make anything fail) is simply a waste of our time and money 

