### PR TITLE
Move to ROS2 Jazzy Jalisco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     uses: lf-lang/lingua-franca/.github/workflows/latest-release.yml@master
     
   check-compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: find-latest-release
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
           compiler_ref: ${{ needs.find-latest-release.outputs.ref }} # for testing, consider replacing with "master"
 
   check-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: find-latest-release
     steps:
       - uses: actions/checkout@v4

--- a/utils/scripts/setup-env.bash
+++ b/utils/scripts/setup-env.bash
@@ -29,19 +29,23 @@ for arg in "$@"; do
 done
 
 # Install dependencies
+
+# We need python3.10 to use LF
+sudo add-apt-repository -y 'ppa:deadsnakes/ppa'
 sudo apt-get update
+
 ## Setup C, C++, Python, Rust, protobuf, gRPC, gnuplot
 sudo apt-get install --assume-yes \
     build-essential \
-    python3 python3-dev python3-pip \
+    python3.10 python3.10-dev \
     rustc cargo \
     libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf \
     protobuf-compiler-grpc libgrpc-dev libgrpc++-dev gnuplot
     
-python3 -m pip install --upgrade pip
+python3.10 -m pip install --upgrade pip
 # Install python dependencies and
 # latest CMake; see https://www.kitware.com/cmake-python-wheels/ https://askubuntu.com/a/1070770
-sudo python3 -m pip install --exists-action i requests setuptools cmake
+sudo python3.10 -m pip install --exists-action i requests setuptools cmake
 
 if [ $SETUP_NETWORK = true ]; then 
     # Install support for protocol buffers

--- a/utils/scripts/setup-env.bash
+++ b/utils/scripts/setup-env.bash
@@ -73,7 +73,9 @@ if [ $SETUP_ROS = true ]; then
         OS_VERSION_ID="$(\. /etc/os-release && echo "${VERSION_ID}")"
         # See https://www.ros.org/reps/rep-2000.html
         ROS_VERSION_CODENAME=""
-        if ([[ "${OS_ID}" = "ubuntu" ]] && [[ ! "${OS_VERSION_ID}" < "22.04" ]]) || \
+        if [[ "${OS_ID}" = "ubuntu" ]] && [[ ! "${OS_VERSION_ID}" < "24.04" ]]; then
+            ROS_VERSION_CODENAME="jazzy"
+        elif ([[ "${OS_ID}" = "ubuntu" ]] && [[ ! "${OS_VERSION_ID}" < "22.04" ]]) || \
         ([[ "${OS_ID}" = "debian" ]] && [[ "${OS_VERSION_ID}" = "11" ]]); then
             ROS_VERSION_CODENAME="iron"
         elif [[ "${OS_ID}" = "ubuntu" ]] && [[ ! "${OS_VERSION_ID}" < "20.04" ]]; then


### PR DESCRIPTION
This PR pins the CI runner to `ubuntu-24.04` (it was using this already, through `ubuntu-latest`), it also install ROS2 Jazzy rather than ROS2 Iron because the latter is not supported on ubuntu 24.04. I have already made that move in the CI for `lingua-franca`. Finally, since our Python support does not include python3.12 which is the default version on ubuntu24, we must manually install python3.10