### PR TITLE
Use Python 3.12 not 3.10 and eliminate dependence on deadsnakes PPA.

### DIFF
--- a/examples/C/src/Delay.lf
+++ b/examples/C/src/Delay.lf
@@ -53,7 +53,7 @@ reactor Print {
   input x: int
 
   reaction(x) {=
-    printf("Logical time: %lld, Physical time %lld"
+    printf("Logical time: " PRINTF_TIME ", Physical time " PRINTF_TIME
         ", Value: %d\n",
         lf_time_logical_elapsed(),
         lf_time_physical_elapsed(), x->value);

--- a/examples/C/src/DistributedDatabase/ReplicatedDatabase.lf
+++ b/examples/C/src/DistributedDatabase/ReplicatedDatabase.lf
@@ -76,8 +76,8 @@ reactor Server(
     lf_set(update, self->update_amount);
   =} deadline(update_deadline) {=
     tag_t tag = lf_tag();
-    lf_print_error("At tag (%lld, %u), deadline missed at database \"%s\". Rejecting update.\n"
-        "   Elapsed physical time is %lld.",
+    lf_print_error("At tag " PRINTF_TAG ", deadline missed at database \"%s\". Rejecting update.\n"
+        "   Elapsed physical time is " PRINTF_TIME ".",
         tag.time - lf_time_start(),
         tag.microstep,
         self->name,
@@ -86,7 +86,7 @@ reactor Server(
   =}
 
   reaction(reply) {=
-    lf_print("***** At tag (%lld, %u), server \"%s\" reports balance: %d.",
+    lf_print("***** At tag " PRINTF_TAG ", server \"%s\" reports balance: %d.",
       lf_time_logical_elapsed(), lf_tag().microstep, self->server_name, reply->value
     );
     self->queries_outstanding--;
@@ -155,8 +155,8 @@ reactor Database(name: char* = "unnamed database", num_remote_inputs: int = 1) {
         self->record += remote_update[i]->value;
       }
     }
-    lf_print("At tag (%lld, %u), database \"%s\" updated balance to %d.\n"
-        "   Elapsed physical time is %lld.",
+    lf_print("At tag " PRINTF_TAG ", database \"%s\" updated balance to %d.\n"
+        "   Elapsed physical time is " PRINTF_TIME ".",
         lf_time_logical() - lf_time_start(), lf_tag().microstep,
         self->name,
         self->record,
@@ -166,10 +166,10 @@ reactor Database(name: char* = "unnamed database", num_remote_inputs: int = 1) {
     #ifdef FEDERATED_DECENTRALIZED
         for (int i = 0; i < remote_update_width; i++) {
           if (remote_update[i]->is_present) {
-            lf_print_warning("At tag (%lld, %u), database \"%s\" "
-                "received remote update (%d) with intended tag (%lld, %u).\n"
+            lf_print_warning("At tag " PRINTF_TAG ", database \"%s\" "
+                "received remote update (%d) with intended tag " PRINTF_TAG ".\n"
                 "   Balance previously reported may have been incorrect.\n"
-                "   Elapsed physical time is %lld.",
+                "   Elapsed physical time is " PRINTF_TIME ".",
                 current_tag.time - lf_time_start(),
                 current_tag.microstep,
                 self->name,

--- a/examples/C/src/DistributedResourceManagement/ResourceManagement.lf
+++ b/examples/C/src/DistributedResourceManagement/ResourceManagement.lf
@@ -77,7 +77,7 @@ reactor Client(
   reaction(startup, release_trigger) -> release, request_trigger {=
     if (release_trigger->is_present) {
       tag_t tag = lf_tag();
-      lf_print("%s (ID %d): At tag (%lld, %u), released access.",
+      lf_print("%s (ID %d): At tag " PRINTF_TAG ", released access.",
         self->name,
         self->id,
         tag.time - lf_time_start(), tag.microstep
@@ -89,7 +89,7 @@ reactor Client(
 
   reaction(request_trigger) -> request {=
     tag_t tag = lf_tag();
-    lf_print("%s (ID %d): At tag (%lld, %u), requesting access.",
+    lf_print("%s (ID %d): At tag " PRINTF_TAG ", requesting access.",
       self->name,
       self->id,
       tag.time - lf_time_start(), tag.microstep
@@ -100,7 +100,7 @@ reactor Client(
 
   reaction(grant) -> release_trigger {=
     tag_t tag = lf_tag();
-    lf_print("%s (ID %d): At tag (%lld, %u), granted access.",
+    lf_print("%s (ID %d): At tag " PRINTF_TAG ", granted access.",
       self->name,
       self->id,
       tag.time - lf_time_start(), tag.microstep

--- a/examples/C/src/Parallelism/Pipeline.lf
+++ b/examples/C/src/Parallelism/Pipeline.lf
@@ -42,7 +42,7 @@ reactor Receive {
   input in: int
 
   reaction(in) {=
-    lf_print("At elapsed tag (%lld, %d), received %d.",
+    lf_print("At elapsed tag " PRINTF_TAG ", received %d.",
       lf_time_logical_elapsed(), lf_tag().microstep,
       in->value
     );

--- a/examples/C/src/ROS/PTIDES-ROS.lf
+++ b/examples/C/src/ROS/PTIDES-ROS.lf
@@ -93,7 +93,7 @@ reactor MessageGenerator {
         // std::cout << "Executing timer reaction." << std::endl;
         message.data = lf_time_logical() + MSEC(25); // Add a 25 msec delay
         // RCLCPP_INFO(self->minimal_publisher->get_logger(),
-        //      "Sender publishing: '%lld'", message.data);
+        //      "Sender publishing: '" PRINTF_TIME "'", message.data);
         self->minimal_publisher->publisher_->publish(message);
         rclcpp::spin_some(self->minimal_publisher);
         // std::cout << "Done executing timer reaction." << std::endl;
@@ -118,7 +118,7 @@ reactor MessageReceiver {
       private:
         void topic_callback(const std_msgs::msg::Int64::SharedPtr msg) const {
           // writable_string[msg->data.length()] = '\0'; // Terminate with 0
-          // RCLCPP_INFO(this->get_logger(), "I heard: '%lld'", msg->data);
+          // RCLCPP_INFO(this->get_logger(), "I heard: '" PRINTF_TIME "'", msg->data);
           // std::cout << "At tag (" << lf_time_logical_elapsed() << ","
           //      << lf_tag().microstep << ") calling schedule_copy with value "
           //      << msg->data  << "." << std::endl;
@@ -142,12 +142,12 @@ reactor MessageReceiver {
 
   reaction(ros_message_a) -> ros_message_l {=
     // std::cout << "Physical action triggered." << std::endl;
-    // printf("Received: %lld.\n", ros_message_a->value);
+    // printf("Received: " PRINTF_TIME ".\n", ros_message_a->value);
     lf_schedule(ros_message_l, ros_message_a->value - lf_time_logical());
   =}
 
   reaction(ros_message_l) {=
-    printf("PTIDES reaction called at tag (%lld, %u).\n",
+    printf("PTIDES reaction called at tag " PRINTF_TAG ".\n",
          lf_time_logical_elapsed(),
          lf_tag().microstep);
   =}

--- a/examples/C/src/deadlines/AnytimePrime.lf
+++ b/examples/C/src/deadlines/AnytimePrime.lf
@@ -58,7 +58,7 @@ reactor Print {
   input in: {= long long =}
 
   reaction(in) {=
-    printf("Largest prime found within the deadline: %lld\n", in->value);
+    printf("Largest prime found within the deadline: " PRINTF_TIME "\n", in->value);
   =}
 }
 

--- a/examples/C/src/deadlines/Deadline.lf
+++ b/examples/C/src/deadlines/Deadline.lf
@@ -46,7 +46,7 @@ reactor Sensor {
   =}
 
   reaction(response) -> y {=
-    printf("Reacting to physical action at %lld\n", lf_time_logical_elapsed());
+    printf("Reacting to physical action at " PRINTF_TIME "\n", lf_time_logical_elapsed());
     lf_set(y, true);
   =}
 }

--- a/examples/C/src/distributed/HelloWorld.lf
+++ b/examples/C/src/distributed/HelloWorld.lf
@@ -48,7 +48,7 @@ reactor MessageGenerator(prefix: string = "") {
     lf_set_array(message, buffer, length);
 
     tag_t tag = lf_tag();
-    lf_print("At (elapsed) logical tag (%lld, %u), source sends message: %s",
+    lf_print("At (elapsed) logical tag " PRINTF_TAG ", source sends message: %s",
       tag.time - lf_time_start(), tag.microstep,
       message->value
     );
@@ -65,7 +65,7 @@ reactor PrintMessage {
 
   reaction(message) {=
     tag_t tag = lf_tag();
-    lf_print("At (elapsed) logical tag (%lld, %u), print receives: %s",
+    lf_print("At (elapsed) logical tag " PRINTF_TAG ", print receives: %s",
       tag.time - lf_time_start(), tag.microstep,
       message->value
     );

--- a/examples/C/src/distributed/HelloWorldDecentralized.lf
+++ b/examples/C/src/distributed/HelloWorldDecentralized.lf
@@ -31,14 +31,14 @@ reactor PrintMessageWithDetector(offset: time = 10 msec) extends PrintMessage {
   reaction(message) {=
     // Empty. The base class will react and report the incoming message.
   =} STAA(0) {=
-    lf_print_warning("Message is tardy. Intended tag is (%lld, %u).",
+    lf_print_warning("Message is tardy. Intended tag is " PRINTF_TAG ".",
       message->intended_tag.time - lf_time_start(), message->intended_tag.microstep
     );
   =}
 
   reaction(local) {=
     tag_t tag = lf_tag();
-    lf_print("Timer triggered at logical tag (%lld, %u).",
+    lf_print("Timer triggered at logical tag " PRINTF_TAG ".",
       tag.time - lf_time_start(), tag.microstep
     );
   =}

--- a/examples/C/src/fault-tolerance/lib/FaultTolerantTaskTemplate.lf
+++ b/examples/C/src/fault-tolerance/lib/FaultTolerantTaskTemplate.lf
@@ -55,7 +55,7 @@ reactor Trigger(task_num: uint16_t = 0) {
         segment_start_num = 1; // Start from segment 1.
         lf_set(instance_start_time, lf_time_logical_elapsed());
         // When timer triggers.
-        lf_print_log("**** New instance of task %d starting. Current Logical time: %lld msecs, microstep: %d, Physical time: %lld msecs.\n", self->task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
+        lf_print_log("**** New instance of task %d starting. Current Logical time: " PRINTF_TIME " ms, microstep: %d, Physical time: " PRINTF_TIME " ms.\n", self->task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
       } else {
         // New instance should only be triggered when value is 0. Don't schedule to trigger task.
         return;
@@ -88,7 +88,7 @@ reactor AdvanceTime(
     }
 
     // Schedule logical action to advance time.
-    lf_print_log("TASK%d: Current Logical time: %lld msecs, microstep: %d, Physical time: %lld msecs.", self->task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
+    lf_print_log("TASK%d: Current Logical time: " PRINTF_TIME " ms , microstep: %d, Physical time: " PRINTF_TIME " ms.", self->task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
 
     // Caluculate the time of the total successed segments.
     int total_success_time = 0; // msecs
@@ -99,7 +99,7 @@ reactor AdvanceTime(
     if(failed_seg_num == 0) {
       // Task is finished. Advance as much as the sucessed segments.
       lf_schedule_int(advance_lt, total_success_time * MSEC(1), 0);
-      lf_print_log("TASK%d: All segments finished. %d task(s) success. Advancing logical time by %d msecs. \n", self->task_num, num_of_success, total_success_time);
+      lf_print_log("TASK%d: All segments finished. %d task(s) success. Advancing logical time by %d ms. \n", self->task_num, num_of_success, total_success_time);
     } else {
       // Segment failed. Advance as much as successed segments + 1 failed segment.
       lf_schedule_int(advance_lt, total_success_time * MSEC(1) + self->wcet_f[failed_seg_num - 1] * MSEC(1), failed_seg_num);
@@ -201,12 +201,12 @@ reactor Coordinator {
 
       instant_t min_instance_finish_time = lf_time_logical_elapsed() + total_success_time * MSEC(1);
       if(min_instance_finish_time > self->instance_start_time + (self->task_info.dead_line * MSEC(1))) {
-        lf_print_log("TASK%d: Current Logical time: %lld msecs, microstep: %d, Physical time: %lld msecs.", self->task_info.task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
-        lf_print_log("TASK%d: ****Logical time deadline violation predicted.\nDeadline is: %lld msecs, while minimum predicted instance finish time is %lld msecs.\nDropping left over tasks, and giving up instance.\n", self->task_info.task_num, (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1), min_instance_finish_time / MSEC(1));
+        lf_print_log("TASK%d: Current Logical time: " PRINTF_TIME " ms, microstep: %d, Physical time: " PRINTF_TIME " ms.", self->task_info.task_num, lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1));
+        lf_print_log("TASK%d: ****Logical time deadline violation predicted.\nDeadline is: " PRINTF_TIME " ms, while minimum predicted instance finish time is " PRINTF_TIME " ms.\nDropping left over tasks, and giving up instance.\n", self->task_info.task_num, (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1), min_instance_finish_time / MSEC(1));
       } else if(self->task_info.dead_line * MSEC(1) < lf_time_logical_elapsed() - self->instance_start_time) {
         // Checks if there are any logical time deadline misses.
         // Should never pass here.
-        lf_print_log("\nLogical time deadline violation detected on Logical time: %lld msecs, microstep: %d, Physical time: %lld msecs.\nDeadline was: %lld msecs.\n", lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1), (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1));
+        lf_print_log("\nLogical time deadline violation detected on Logical time: " PRINTF_TIME " ms, microstep: %d, Physical time: " PRINTF_TIME " ms.\nDeadline was: " PRINTF_TIME " ms.\n", lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1), (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1));
       } else {
         // Did not violate predicted deadline.
         lf_set(out, failed_seg->value);
@@ -215,7 +215,7 @@ reactor Coordinator {
   =} deadline(3 sec) {=
     // Checks if there are any Physical time - Logical start time of task deadline misses.
     // Should never pass here.
-    lf_print("Deadline violation detected on Logical time: %lld msecs, microstep: %d, Physical time: %lld msecs.\nDeadline was: %lld msecs.\n", lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1), (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1));
+    lf_print("Deadline violation detected on Logical time: " PRINTF_TIME " ms, microstep: %d, Physical time: " PRINTF_TIME " ms.\nDeadline was: " PRINTF_TIME " ms.\n", lf_time_logical_elapsed() / MSEC(1), lf_tag().microstep, lf_time_physical_elapsed() / MSEC(1), (self->task_info.dead_line * MSEC(1) + self->instance_start_time)/ MSEC(1));
   =}
 }
 

--- a/examples/C/src/patterns/lib/SendersAndReceivers.lf
+++ b/examples/C/src/patterns/lib/SendersAndReceivers.lf
@@ -38,7 +38,7 @@ reactor Receive {
   input in: int
 
   reaction(in) {=
-    lf_print("At elapsed tag (%lld, %d), received %d.",
+    lf_print("At elapsed tag " PRINTF_TAG ", received %d.",
       lf_time_logical_elapsed(), lf_tag().microstep,
       in->value
     );
@@ -63,7 +63,7 @@ reactor SendOnceAndReceive {
   =}
 
   reaction(in) {=
-    lf_print("At tag (%lld, %d), received %d.",
+    lf_print("At tag " PRINTF_TAG ", received %d.",
       lf_time_logical_elapsed(),
       lf_tag().microstep,
       in->value
@@ -129,7 +129,7 @@ reactor SendPeriodicallyAndReceiveMultiport(
   =}
 
   reaction(in) {=
-    lf_print("At tag (%lld, %d), received:",
+    lf_print("At tag " PRINTF_TAG ", received:",
       lf_time_logical_elapsed(), lf_tag().microstep
     );
     for (int i = 0; i < self->width; i++) {
@@ -158,7 +158,7 @@ reactor LocalRemoteUpdates(offset: time = 0, period: time = 1 sec, increment: in
 
   reaction(in) {=
     self->count += in->value;
-    lf_print("At tag (%lld, %d), count is %d",
+    lf_print("At tag " PRINTF_TAG ", count is %d",
       lf_time_logical_elapsed(), lf_tag().microstep,
       self->count
     );

--- a/examples/C/src/reflex-game/ReflexGameTest.lf
+++ b/examples/C/src/reflex-game/ReflexGameTest.lf
@@ -52,7 +52,7 @@ main reactor {
       fflush(stdout);
     } else {
       interval_t elapsed = lf_time_logical() - self->request_time;
-      printf("Character entered: %c after %lld nsec.\n", *a->value, elapsed);
+      printf("Character entered: %c after " PRINTF_TIME " nsec.\n", *a->value, elapsed);
     }
   =}
 }

--- a/examples/C/src/rhythm/Rhythm.lf
+++ b/examples/C/src/rhythm/Rhythm.lf
@@ -146,9 +146,9 @@ reactor RhythmSource(
       mkdir("log", 0755);
       int fed_id = lf_fed_id();
       if (fed_id < 0) {
-        sprintf(log_file_name, "log/Rhythm_%lld.log", lf_time_logical());
+        sprintf(log_file_name, "log/Rhythm_" PRINTF_TIME ".log", lf_time_logical());
     } else {
-        sprintf(log_file_name, "log/Rhythm_%d_%lld.log", fed_id, lf_time_logical());
+        sprintf(log_file_name, "log/Rhythm_%d_" PRINTF_TIME ".log", fed_id, lf_time_logical());
       }
     }
     if (start_sensor_simulator(
@@ -248,7 +248,7 @@ reactor RhythmSource(
 
   reaction(tempo_change_in) {=
     self->tick_duration -= tempo_change_in->value;
-    lf_print("REMOTE: Changing the tempo period by %lld ns.",
+    lf_print("REMOTE: Changing the tempo period by " PRINTF_TIME " ns.",
       -tempo_change_in->value
     );
   =}

--- a/examples/C/src/rhythm/SensorSimulator.lf
+++ b/examples/C/src/rhythm/SensorSimulator.lf
@@ -29,11 +29,11 @@ main reactor {
   =}
 
   reaction(r) {=
-    lf_print("Elapsed logical time: %lld.", lf_time_logical_elapsed());
+    lf_print("Elapsed logical time: " PRINTF_TIME ".", lf_time_logical_elapsed());
     show_tick(".");
   =}
 
   reaction(key) {=
-    lf_print("You typed '%s' at elapsed time %lld.", key->value, lf_time_logical_elapsed());
+    lf_print("You typed '%s' at elapsed time " PRINTF_TIME ".", key->value, lf_time_logical_elapsed());
   =}
 }

--- a/examples/C/src/rosace/AircraftSimulator.lf
+++ b/examples/C/src/rosace/AircraftSimulator.lf
@@ -33,8 +33,8 @@ preamble {=
   // Trimming parameters
   // These may be overridden in the top-level .lf file.
   #ifndef Va_eq
-  #define Va_eq (230.0)   // Nominal airspeed?
-  #define h_eq (10000.0)
+  #define Va_eq 230.0   // Nominal airspeed?
+  #define h_eq 10000.0
 
   #define delta_th_eq (1.5868660794926)
   #define delta_e_eq (0.012009615652468)

--- a/examples/C/src/rosace/Rosace.lf
+++ b/examples/C/src/rosace/Rosace.lf
@@ -56,8 +56,8 @@ import PrintToFile from "../lib/PrintToFile.lf"
 preamble {=
   // Shared constants.
   // Trimming parameters
-  #define Va_eq (230.0)   // Nominal airspeed?
-  #define h_eq (10000.0)
+  #define Va_eq 230.0   // Nominal airspeed?
+  #define h_eq 10000.0
 
   #define delta_th_eq (1.5868660794926)
   #define delta_e_eq (0.012009615652468)

--- a/examples/C/src/rosace/RosaceController.lf
+++ b/examples/C/src/rosace/RosaceController.lf
@@ -34,8 +34,8 @@ preamble {=
   // Trimming parameters
   // These may be overridden in the top-level .lf file.
   #ifndef Va_eq
-  #define Va_eq (230.0)   // Nominal airspeed?
-  #define h_eq (10000.0)
+  #define Va_eq 230.0   // Nominal airspeed?
+  #define h_eq 10000.0
 
   #define delta_th_eq (1.5868660794926)
   #define delta_e_eq (0.012009615652468)

--- a/examples/C/src/rosace/RosaceWithUI.lf
+++ b/examples/C/src/rosace/RosaceWithUI.lf
@@ -55,8 +55,8 @@ import ServerUI from "../lib/ServerUI.lf"
 preamble {=
   // Shared constants.
   // Trimming parameters
-  #define Va_eq (230.0)   // Nominal airspeed?
-  #define h_eq (10000.0)
+  #define Va_eq 230.0   // Nominal airspeed?
+  #define h_eq 10000.0
 
   #define delta_th_eq (1.5868660794926)
   #define delta_e_eq (0.012009615652468)

--- a/examples/C/src/rosace/build_run_plot.sh
+++ b/examples/C/src/rosace/build_run_plot.sh
@@ -20,7 +20,7 @@ fi
 
 # Build the generated code.
 cd ${LF_SOURCE_GEN_DIRECTORY}
-cmake -DLF_THREADED=1 .
+cmake .
 cmake --build .
 
 # Move the executable to the bin directory.

--- a/examples/C/src/rosace/fault-tolerance/RosaceControllerWithReExecution.lf
+++ b/examples/C/src/rosace/fault-tolerance/RosaceControllerWithReExecution.lf
@@ -36,7 +36,12 @@ reactor VaControl50Body extends TaskBody {
     const REAL_TYPE K1_Va     = -0.486813084356079;
     const REAL_TYPE K1_Vz     = -0.077603095495388;
     const REAL_TYPE K1_q      = 21.692383376322041;
-    const REAL_TYPE Va_eq       = 230.0;
+    // Guard against the #define Va_eq from RosaceController.lf being injected into the same
+    // compilation unit (GCC 13+ / Ubuntu 24.04): a bare `const REAL_TYPE Va_eq` declaration
+    // would be macro-expanded to `const REAL_TYPE 230.0`, which is invalid C.
+    #ifndef Va_eq
+    #define Va_eq 230.0
+    #endif
 
     int Va_control_50(REAL_TYPE Va_f, REAL_TYPE Vz_f, REAL_TYPE q_f, REAL_TYPE Va_c, REAL_TYPE* output, REAL_TYPE* saved_y, REAL_TYPE* saved_integrator,int seg_start_num){
     	static REAL_TYPE y = 0.0;

--- a/examples/C/src/rosace/fault-tolerance/RosaceWithReExecution.lf
+++ b/examples/C/src/rosace/fault-tolerance/RosaceWithReExecution.lf
@@ -22,8 +22,8 @@ import PrintToFile from "../../lib/PrintToFile.lf"
 
 preamble {=
   // Trimming parameters: define the reference flight condition of the aircraft.
-  #define Va_eq (230.0)   // Nominal airspeed
-  #define h_eq (10000.0)  // Nominal altitude
+  #define Va_eq 230.0   // Nominal airspeed
+  #define h_eq 10000.0  // Nominal altitude
 =}
 
 main reactor(filter_period: time = 10 ms) {

--- a/examples/CCpp/DoorLock/src/lib/UserInteraction.lf
+++ b/examples/CCpp/DoorLock/src/lib/UserInteraction.lf
@@ -58,7 +58,7 @@ reactor UserInteraction {
   =}
 
   reaction(key) -> door, button, fob, mobile {=
-    // lf_print("You typed '%c' at elapsed time %lld.", key->value, lf_time_logical_elapsed());
+    // lf_print("You typed '%c' at elapsed time " PRINTF_TIME ".", key->value, lf_time_logical_elapsed());
 
     switch(key->value) {
     case 'o':

--- a/examples/Python/src/YOLOv5/YOLOv5_Webcam.lf
+++ b/examples/Python/src/YOLOv5/YOLOv5_Webcam.lf
@@ -138,7 +138,7 @@ reactor Plotter(label_deadline = 100 msec) {
 
 main reactor {
   # Offset allows time for the model to load.
-  webcam = new WebCamAsync(webcam_id = 0, offset = 2 s)
+  webcam = new WebCamAsync(webcam_id=0, offset = 2 s)
   dnn = new DNN()
   plotter = new Plotter()
   display = new Display()

--- a/experiments/C/src/Controller/ResponseTime.lf
+++ b/experiments/C/src/Controller/ResponseTime.lf
@@ -27,7 +27,7 @@ reactor PhysicalPlant {
 
   reaction(control) {=
     instant_t control_time = lf_time_physical();
-    lf_print("Latency %lld.", control_time - self->last_sensor_time);
+    lf_print("Latency " PRINTF_TIME ".", control_time - self->last_sensor_time);
   =} STP(33 msec) {=
     lf_print_warning("STP violation.");
   =}

--- a/experiments/C/src/Controller/ResponseTime2.lf
+++ b/experiments/C/src/Controller/ResponseTime2.lf
@@ -30,8 +30,8 @@ reactor PhysicalPlant {
 
   reaction(control) {=
     instant_t control_time = lf_time_physical();
-    lf_print("Latency %lld.", control_time - self->previous_sensor_time);
-    lf_print("Logical time: %lld.", lf_time_logical_elapsed());
+    lf_print("Latency " PRINTF_TIME ".", control_time - self->previous_sensor_time);
+    lf_print("Logical time: " PRINTF_TIME ".", lf_time_logical_elapsed());
   =} STP(33 msec) {=
     lf_print_warning("STP violation.");
   =}

--- a/experiments/C/src/Controller/ResponseTime3.lf
+++ b/experiments/C/src/Controller/ResponseTime3.lf
@@ -42,9 +42,9 @@ reactor PhysicalPlant {
 
   reaction(control) {=
     instant_t control_time = lf_time_physical();
-    lf_print("Latency %lld.", control_time - self->previous_sensor_time);
-    lf_print("Logical time: %lld.", lf_time_logical_elapsed());
-    lf_print("Lag: %lld.", lf_time_physical_elapsed() - lf_time_logical_elapsed());
+    lf_print("Latency " PRINTF_TIME ".", control_time - self->previous_sensor_time);
+    lf_print("Logical time: " PRINTF_TIME ".", lf_time_logical_elapsed());
+    lf_print("Lag: " PRINTF_TIME ".", lf_time_physical_elapsed() - lf_time_logical_elapsed());
   =} STP(33 msec) {=
     lf_print_warning("STP violation.");
   =}

--- a/experiments/C/src/Intersection/Intersection.lf
+++ b/experiments/C/src/Intersection/Intersection.lf
@@ -77,7 +77,7 @@ reactor Vehicle(
   =}
 
   reaction(grant) {=
-    lf_print("Granted access at elapsed logical time %lld. Physical time is %lld",
+    lf_print("Granted access at elapsed logical time " PRINTF_TIME ". Physical time is " PRINTF_TIME,
       lf_time_logical_elapsed(),
       lf_time_physical_elapsed()
     );
@@ -131,7 +131,7 @@ reactor RSU(
             );
         self->earliest_free = response.arrival_time + time_in_intersection;
 
-        lf_print("*** Grant access to vehicle %d to enter at time %lld. Next available time is %lld",
+        lf_print("*** Grant access to vehicle %d to enter at time " PRINTF_TIME ". Next available time is " PRINTF_TIME,
           i,
           response.arrival_time - lf_time_start(),
           self->earliest_free - lf_time_start()

--- a/experiments/C/src/Logic/Logic.lf
+++ b/experiments/C/src/Logic/Logic.lf
@@ -37,7 +37,7 @@ reactor LogicalAnd {
   input b: bool
 
   reaction(a, b) {=
-    printf("Output: %d, tag: (%lld, %u)\n",
+    printf("Output: %d, tag: " PRINTF_TAG "\n",
       a->is_present & b->is_present, lf_time_logical_elapsed(), lf_tag().microstep
     );
   =}

--- a/utils/scripts/setup-env.bash
+++ b/utils/scripts/setup-env.bash
@@ -94,8 +94,15 @@ if [ $SETUP_ROS = true ]; then
             if [ "${OS_ID}" != "ubuntu" ] ; then 
                 echo "This script has only been tested on ubuntu. Proceed with caution."
             else
-                # On Ubuntu, we need to add universe; 
-                sudo add-apt-repository universe --yes
+                # Enable the universe component directly to avoid contacting Launchpad
+                # (add-apt-repository universe makes a network call to launchpad.net which can time out)
+                if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+                    # Ubuntu 24.04+ uses deb822 format
+                    sudo sed -i 's/^Components: main$/Components: main universe/' /etc/apt/sources.list.d/ubuntu.sources
+                else
+                    # Ubuntu 22.04 and earlier use the traditional sources.list format
+                    sudo sed -i 's/^\(deb [^ ]* [^ ]* main\)$/\1 universe/' /etc/apt/sources.list
+                fi
             fi
             
             sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/utils/scripts/setup-env.bash
+++ b/utils/scripts/setup-env.bash
@@ -33,24 +33,18 @@ done
 # Update package index first
 sudo apt-get update
 
-# Make add-apt-repository available
-sudo apt-get install --assume-yes software-properties-common
-# We need python3.10 to use LF
-sudo add-apt-repository -y 'ppa:deadsnakes/ppa'
-sudo apt-get update
-
 ## Setup C, C++, Python, Rust, protobuf, gRPC, gnuplot
 sudo apt-get install --assume-yes \
     build-essential \
-    python3.10 python3.10-dev python3.10-venv python3.10-distutils \
+    python3 python3-dev python3-venv \
     rustc cargo \
     libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf \
     protobuf-compiler-grpc libgrpc-dev libgrpc++-dev gnuplot libasound2-dev libfluidsynth-dev libgpiod-dev
-    
-curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+
+curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 # Install python dependencies and
 # latest CMake; see https://www.kitware.com/cmake-python-wheels/ https://askubuntu.com/a/1070770
-sudo python3.10 -m pip install --exists-action i requests setuptools cmake
+sudo python3 -m pip install --exists-action i requests setuptools cmake
 
 if [ $SETUP_NETWORK = true ]; then 
     # Install support for protocol buffers

--- a/utils/scripts/setup-lf.bash
+++ b/utils/scripts/setup-lf.bash
@@ -82,5 +82,8 @@ case "$RELEASE_BUILD" in
     # Here, we ignore the actual build name (the original name of the file and the original first directory).
     tar -xf lf.tar.gz -C lingua-franca --strip-components 1
     rm lf.tar.gz
+    # Symlink lfc into the system PATH so it is available regardless of how the shell is invoked
+    # (e.g. devcontainer exec does not always apply remoteEnv.PATH from devcontainer.json)
+    sudo ln -sf "$(pwd)/lingua-franca/bin/lfc" /usr/local/bin/lfc
     ;;
 esac


### PR DESCRIPTION
This PR switches from Python 3.10 to 3.12, which is the default Python on on Ubuntu 24.04, which is what CI uses.
Previously, to get Python 3.10, the CI script relied on the deadsnakes PPA, which it downloaded from a repo that appears to no longer exist (or at least has been down for days).

This PR also eliminates a number of warnings and formats one file.